### PR TITLE
Added a dash after multiline variable declaration to fix syntax issue.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,7 +14,7 @@ tomcat_java_opts: >-
 
 
 
-tomcat_catalina_opts: >
+tomcat_catalina_opts: >-
   -Doom.sun.management.jmxremote
   -Dcom.sun.management.remote.port=8999
   -Dcom.sun.management.remote.ssl=false


### PR DESCRIPTION
Was seeing an extra line before closing quote in SystemD service from non-escaped variables.
Caused tomcat service not to start and role to fail to execute fully.
Behavior was seen on Oracle Linux 7.